### PR TITLE
Feat: Add Wrappers for MPI_AllGatherv

### DIFF
--- a/src/mpi_c_bindings.f90
+++ b/src/mpi_c_bindings.f90
@@ -221,6 +221,20 @@ module mpi_c_bindings
             integer(c_int) :: c_mpi_cart_create
         end function
 
+        function c_mpi_allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, &
+                                  displs, recvtype, comm) bind(C, name="MPI_Allgatherv")
+            use iso_c_binding, only: c_int, c_ptr
+            type(c_ptr), value :: sendbuf
+            integer(c_int), value :: sendcount
+            integer(kind=MPI_HANDLE_KIND), value :: sendtype
+            type(c_ptr), value :: recvbuf
+            integer(c_int), dimension(*) :: recvcounts
+            integer(c_int), dimension(*) :: displs
+            integer(kind=MPI_HANDLE_KIND), value :: recvtype
+            integer(kind=MPI_HANDLE_KIND), value :: comm
+            integer(c_int) :: c_mpi_allgatherv
+        end function c_mpi_allgatherv
+
         function c_mpi_cart_coords(comm, rank, maxdims, coords) bind(C, name="MPI_Cart_coords")
             use iso_c_binding,  only: c_int, c_ptr
             integer(kind=MPI_HANDLE_KIND), value :: comm

--- a/tests/allgatherv_1.f90
+++ b/tests/allgatherv_1.f90
@@ -1,0 +1,59 @@
+program allgatherv_1
+    use mpi
+    implicit none
+    integer :: ierr, rank, size
+    integer, allocatable :: sendbuf(:), recvbuf(:)
+    integer, allocatable :: recvcounts(:), displs(:)
+    integer :: sendcount, i, total
+    logical :: error
+
+    ! Initialize MPI
+    call MPI_Init(ierr)
+    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+    call MPI_Comm_size(MPI_COMM_WORLD, size, ierr)
+
+    ! Each process sends 'rank + 1' integers
+    sendcount = rank + 1
+    allocate(sendbuf(sendcount))
+    do i = 1, sendcount
+        sendbuf(i) = rank * 100 + i  ! Unique values per process
+    end do
+
+    ! All processes allocate receive buffers
+    allocate(recvcounts(size))
+    allocate(displs(size))
+    total = 0
+    do i = 1, size
+        recvcounts(i) = i  ! Process i-1 sends i elements
+        displs(i) = total  ! Displacement in recvbuf
+        total = total + recvcounts(i)
+    end do
+    allocate(recvbuf(total))
+    recvbuf = 0
+
+    ! Perform allgather
+    call MPI_Allgatherv(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcounts, &
+                        displs, MPI_INTEGER, MPI_COMM_WORLD, ierr)
+
+    ! Verify results on all processes
+    error = .false.
+    do i = 1, size
+        do sendcount = 1, i
+            if (recvbuf(displs(i) + sendcount) /= (i-1)*100 + sendcount) then
+                print *, "Rank ", rank, ": Error at source rank ", i-1, &
+                         " index ", sendcount, ": expected ", (i-1)*100 + sendcount, &
+                         ", got ", recvbuf(displs(i) + sendcount)
+                error = .true.
+            end if
+        end do
+    end do
+    if (.not. error) then
+        print *, "MPI_Allgatherv test passed on rank ", rank
+    end if
+
+    ! Clean up
+    deallocate(sendbuf, recvbuf, recvcounts, displs)
+    call MPI_Finalize(ierr)
+
+    if (error) stop 1
+end program allgatherv_1


### PR DESCRIPTION
Towards #121 

MPI_Allgatherv is similar to MPI_Gatherv, but instead of gathering data to a single root process, it gathers data to all processes in the communicator.